### PR TITLE
Use isHit() instead of is_null check

### DIFF
--- a/src/ActivityPhp/Server/Cache/CacheHelper.php
+++ b/src/ActivityPhp/Server/Cache/CacheHelper.php
@@ -88,11 +88,7 @@ abstract class CacheHelper // implements CacheInterface
             return false;
         }
 
-        return is_null(
-            self::$pool->getItem(
-                self::key($key)
-            )
-        );
+        return self::$pool->getItem(self::key($key))->isHit();
     }
 
     /**


### PR DESCRIPTION
Figure out the miss. Looking at the interface, it should always return cache item, and then it's possible to use isHit().

Fixes issue #12 