### PR TITLE
Pattern now matches fields with hyphens

### DIFF
--- a/src/ActivityPhp/Server/Http/HttpSignature.php
+++ b/src/ActivityPhp/Server/Http/HttpSignature.php
@@ -28,7 +28,7 @@ class HttpSignature
             ([\w\-\.#\/@]+)
         )",
         (algorithm="(?P<algorithm>[\w\s-]+)",)?
-        (headers="\(request-target\) (?P<headers>[\w\s]+)",)?
+        (headers="\(request-target\) (?P<headers>[\w\s-]+)",)?
         signature="(?P<signature>[\w+\/]+={0,2})"
     /x';       
 


### PR DESCRIPTION
The original pattern would miss fields like 'content-length', which is used in Pleroma's signature.

However, when I went to check https://tools.ietf.org/html/rfc7230:
```
     header-field   = field-name ":" OWS field-value OWS

     field-name     = token
```
```
     token          = 1*tchar

     tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*"
                    / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
                    / DIGIT / ALPHA
                    ; any VCHAR, except delimiters
```
it seems that the pattern could be further extended. 
( But I do think that all headers nowadays will match `[\w\s-]` anyway :P )