### PR TITLE
Update TypeConfiguration namespace in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ You can define 3 different behaviours:
 
 ```php
 use ActivityPhp\Type;
-use ActivityPhp\TypeConfiguration;
+use ActivityPhp\Type\TypeConfiguration;
 
 $note = Type::create('Note');
 


### PR DESCRIPTION
Hi there,

thank you for creating this library! It is very useful,  and I'm using it in one of my projects.
I noticed that one of the examples in the readme shows the wrong namespace for `TypeConfiguration`.

This patch updates the namespace of `TypeConfiguration` in the readme example to `ActivityPhp\Type\TypeConfiguration`.