### PR TITLE
Webfinger's restrictions removed because optionals in specs

### DIFF
--- a/src/ActivityPhp/Server/Http/WebFinger.php
+++ b/src/ActivityPhp/Server/Http/WebFinger.php
@@ -41,13 +41,9 @@ class WebFinger
     public function __construct(array $data)
     {
         foreach (['subject', 'aliases', 'links'] as $key) {
-            if (!isset($data[$key])) {
-                throw new Exception(
-                    "WebFinger profile must contain '$key' property"
-                );
-            }
+            $value = $data[$key] ?? $this->$key;
             $method = 'set' . ucfirst($key);
-            $this->$method($data[$key]);
+            $this->$method($value);
         }
     }
 

--- a/tests/ActivityPhp/Server/WebFingerTest.php
+++ b/tests/ActivityPhp/Server/WebFingerTest.php
@@ -138,32 +138,6 @@ class WebFingerTest extends TestCase
         # data
         return [
 [[
-    'aliases' => ['http//localhost:8000/accounts/bob'],
-    'links' => [
-            [
-                'rel' => 'self',
-                'type' => 'application/activity+json',
-                'href' => 'http://localhost:8000/accounts/bob',
-            ]
-        ]
-    ]                                                                  ], # Missing key: subject
-[[
-    'subject' => 'acct:bob@localhost:8000',
-    'links' => [
-        [
-            'rel' => 'self',
-            'type' => 'application/activity+json',
-            'href' => 'http://localhost:8000/accounts/bob',
-        ]
-    ]
-]                                                                      ], # Missing key: aliases
-[[
-    'subject' => 'acct:bob@localhost:8000',
-    'aliases' => [
-        'http//localhost:8000/accounts/bob'
-    ],
-]                                                                      ], # Missing key: links
-[[
     'subject' => ['acct:bob@localhost:8000'],
     'aliases' => [
         'http//localhost:8000/accounts/bob'


### PR DESCRIPTION
See https://datatracker.ietf.org/doc/html/rfc7033#page-11
Subject set at `SHOULD` but not at `MUST` so it can be controversial. The others are `OPTIONAL`.