### PR TITLE
Fix tests on PHP 8.X

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor
-/cache
 /build
 
+/cache
+.phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /vendor
 /build
 
+# Cache related:
 /cache
 .phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
-/vendor
 /build
 
 # Cache related:
 /cache
 .phpunit.result.cache
+
+# Dependencies related:
+/vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "homepage": "https://github.com/landrok/activitypub",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "guzzlehttp/guzzle": ">=6.3",
         "monolog/monolog": "^1.12|^2.0|^3.0",
         "symfony/http-foundation": ">=3.4",

--- a/tests/ActivityPhp/Server/ConfigurationTest.php
+++ b/tests/ActivityPhp/Server/ConfigurationTest.php
@@ -3,9 +3,9 @@
 namespace ActivityPhpTest\Server;
 
 use ActivityPhp\Server;
-use PHPUnit\Framework\Attributes\DataProvider;
 use ActivityPhp\Server\Configuration;
 use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ConfigurationTest extends TestCase
@@ -21,7 +21,7 @@ class ConfigurationTest extends TestCase
             [['https' => 'bob']  ], # property does not exist
             [['http' => 'bob']   ], # property must have an array as value
         ];
-	}
+    }
 
     #[DataProvider('getFailingInstanceScenarios')]
     public function testFailingInstanceScenarios($data)

--- a/tests/ActivityPhp/Server/ConfigurationTest.php
+++ b/tests/ActivityPhp/Server/ConfigurationTest.php
@@ -3,6 +3,7 @@
 namespace ActivityPhpTest\Server;
 
 use ActivityPhp\Server;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ActivityPhp\Server\Configuration;
 use Exception;
 use PHPUnit\Framework\TestCase;
@@ -16,18 +17,13 @@ class ConfigurationTest extends TestCase
     {
         # data
         return [
-[[['http']]                                                            ], # Key is an array
-[['https' => 'bob']                                                    ], # property does not exist
-[['http' => 'bob']                                                     ], # property must have an array as value
-
+            [[['http']]          ], # Key is an array
+            [['https' => 'bob']  ], # property does not exist
+            [['http' => 'bob']   ], # property must have an array as value
         ];
 	}
 
-    /**
-     * Check that all tests are failing
-     *
-     * @dataProvider      getFailingInstanceScenarios
-     */
+    #[DataProvider('getFailingInstanceScenarios')]
     public function testFailingInstanceScenarios($data)
     {
         $this->expectException(Exception::class);

--- a/tests/ActivityPhp/Server/HelperTest.php
+++ b/tests/ActivityPhp/Server/HelperTest.php
@@ -4,6 +4,7 @@ namespace ActivityPhpTest\Server;
 
 use ActivityPhp\Server\Helper;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class HelperTest extends TestCase
 {
@@ -14,26 +15,24 @@ class HelperTest extends TestCase
     {
         # input / expected
         return [
-['application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
- true                                                                  ], # Allowed
-['application/activity+json', true                                     ], # Allowed
-['*/*', true                                                           ], # Allowed
-['application/json', false                                             ], # Refused
-[[
-  'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
-  'application/json'
-], true                                                                ], # Allowed (array input)
-[[
-  'application/pdf',
-  'application/json'
-], false                                                               ], # Refused (array input)
+            ['application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+             true                                                                  ], # Allowed
+            ['application/activity+json', true                                     ], # Allowed
+            ['*/*', true                                                           ], # Allowed
+            ['application/json', false                                             ], # Refused
+            [[
+                'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+                'application/json'
+            ], true                                                                ], # Allowed (array input)
+            [[
+                'application/pdf',
+                'application/json'
+            ], false                                                               ], # Refused (array input)
 
         ];
 	}
 
-    /**
-     * @dataProvider getAcceptHeaderScenarios
-     */
+    #[DataProvider('getAcceptHeaderScenarios')]
     public function testAcceptHeaderScenarios($input, $expected)
     {
         $this->assertEquals(

--- a/tests/ActivityPhp/Server/OutboxPostTest.php
+++ b/tests/ActivityPhp/Server/OutboxPostTest.php
@@ -4,6 +4,7 @@ namespace ActivityPhpTest\Server;
 
 use ActivityPhp\Server;
 use ActivityPhp\Type;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -17,54 +18,53 @@ class OutboxPostTest extends TestCase
     {
         # Activities or objects
         return [
-['{
-  "@context": ["https://www.w3.org/ns/activitystreams",
-               {"@language": "en"}],
-  "type": "Like",
-  "actor": "https://dustycloud.org/chris/",
-  "name": "Chris liked \'Minimal ActivityPhp update client\'",
-  "object": "https://rhiaro.co.uk/2016/05/minimal-activitypub",
-  "to": ["https://rhiaro.co.uk/#amy",
-         "https://dustycloud.org/followers",
-         "https://rhiaro.co.uk/followers/"],
-  "cc": "https://e14n.com/evan"
-}'                                                                     ], # JSON formatted Like activity
-['{
-  "@context": "https://www.w3.org/ns/activitystreams",
-  "type": "Note",
-  "content": "This is a note",
-  "published": "2015-02-10T15:04:55Z",
-  "to": ["https://example.org/~john/"],
-  "cc": ["https://example.com/~erik/followers",
-         "https://www.w3.org/ns/activitystreams#Public"]
-}'                                                                     ], # JSON formatted Note that should be wrapped into activity
+            ['{
+              "@context": ["https://www.w3.org/ns/activitystreams",
+                           {"@language": "en"}],
+              "type": "Like",
+              "actor": "https://dustycloud.org/chris/",
+              "name": "Chris liked \'Minimal ActivityPhp update client\'",
+              "object": "https://rhiaro.co.uk/2016/05/minimal-activitypub",
+              "to": ["https://rhiaro.co.uk/#amy",
+                     "https://dustycloud.org/followers",
+                     "https://rhiaro.co.uk/followers/"],
+              "cc": "https://e14n.com/evan"
+            }'                                                                     ], # JSON formatted Like activity
+            ['{
+              "@context": "https://www.w3.org/ns/activitystreams",
+              "type": "Note",
+              "content": "This is a note",
+              "published": "2015-02-10T15:04:55Z",
+              "to": ["https://example.org/~john/"],
+              "cc": ["https://example.com/~erik/followers",
+                     "https://www.w3.org/ns/activitystreams#Public"]
+            }'                                                                     ], # JSON formatted Note that should be wrapped into activity
 
 
 
-['{
-  "@context": "https://www.w3.org/ns/activitystreams",
-  "type": "Note",
-  "content": "This is a note",
-  "published": "2015-02-10T15:04:55Z",
-  "to": ["https://example.org/~john/"],
-  "cc": ["https://example.com/~erik/followers",
-         "https://www.w3.org/ns/activitystreams#Public"]
-}',
-'application/ld+json; profile="https://www.w3.org/ns/activitystreams"' ], # Accept headers should be accepted
+            ['{
+              "@context": "https://www.w3.org/ns/activitystreams",
+              "type": "Note",
+              "content": "This is a note",
+              "published": "2015-02-10T15:04:55Z",
+              "to": ["https://example.org/~john/"],
+              "cc": ["https://example.com/~erik/followers",
+                     "https://www.w3.org/ns/activitystreams#Public"]
+            }',
+            'application/ld+json; profile="https://www.w3.org/ns/activitystreams"' ], # Accept headers should be accepted
 
-// ---------------------------------------------------------------------
-// Error scenarios
-// ---------------------------------------------------------------------
-['bad JSON', 'application/activity+json', 400                          ], # Bad JSON payload should return 400 Bad request
-['bad JSON', 'text/html,application/xhtml+xml,application/xml', 400    ], # Accept header MUST be valid
+            // ---------------------------------------------------------------------
+            // Error scenarios
+            // ---------------------------------------------------------------------
+            ['bad JSON', 'application/activity+json', 400                          ], # Bad JSON payload should return 400 Bad request
+            ['bad JSON', 'text/html,application/xhtml+xml,application/xml', 400    ], # Accept header MUST be valid
         ];
 	}
 
     /**
      * Check that all response are valid
-     *
-     * @dataProvider getOutboxPostActivities
      */
+    #[DataProvider('getOutboxPostActivities')]
     public function testOutboxPostActivities($payload, $accept = 'application/activity+json', $code = 201)
     {
         $server = new Server([

--- a/tests/ActivityPhp/Server/WebFingerTest.php
+++ b/tests/ActivityPhp/Server/WebFingerTest.php
@@ -5,6 +5,7 @@ namespace ActivityPhpTest\Server;
 use ActivityPhp\Server;
 use ActivityPhp\Server\Http\WebFinger;
 use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class WebFingerTest extends TestCase
@@ -30,13 +31,13 @@ class WebFingerTest extends TestCase
 
         # handle / method / expected
         return [
-['bob@localhost:8000', 'toArray', $sample                           ], # toArray()
-['bob@localhost:8000', 'getProfileId', $sample['links'][0]['href']  ], # getProfileId()
-['bob@localhost:8000', 'getHandle', substr($sample['subject'], 5)   ], # getHandle()
-['bob@localhost:8000', 'getSubject', $sample['subject']             ], # getSubject()
-['bob@localhost:8000', 'getAliases', $sample['aliases']             ], # getAliases()
-['bob@localhost:8000', 'getLinks', $sample['links']                 ], # getLinks()
-['http://localhost:8000/accounts/bob', 'toArray', $sample           ], # toArray() with an ActivityPhp profile id
+            ['bob@localhost:8000', 'toArray', $sample                           ], # toArray()
+            ['bob@localhost:8000', 'getProfileId', $sample['links'][0]['href']  ], # getProfileId()
+            ['bob@localhost:8000', 'getHandle', substr($sample['subject'], 5)   ], # getHandle()
+            ['bob@localhost:8000', 'getSubject', $sample['subject']             ], # getSubject()
+            ['bob@localhost:8000', 'getAliases', $sample['aliases']             ], # getAliases()
+            ['bob@localhost:8000', 'getLinks', $sample['links']                 ], # getLinks()
+            ['http://localhost:8000/accounts/bob', 'toArray', $sample           ], # toArray() with an ActivityPhp profile id
         ];
 	}
 
@@ -60,27 +61,26 @@ class WebFingerTest extends TestCase
         ];
         #
         return [
-['bob@localhost:9000', 'toArray', $sample                           ], # Bad host with an Handle
-['bob', 'toArray', $sample                                             ], # Malformed handle
-['http://localhost:9000/accounts/bob', 'toArray', $sample           ], # Bad port with an AS id
-['http//localhost:8000/accounts/bob', 'toArray', $sample            ], # Bad scheme
-['bob-subject-array@localhost:8000', 'toArray', $sample             ], # Bad response from server (Subject is an array)
-['bob-malformed-aliases@localhost:8000', 'toArray', $sample         ], # Bad response from server (Aliases must be string[])
-['bob-missing-links@localhost:8000', 'toArray', $sample             ], # Bad response from server (links key is not defined)
-['bob-links-arrays@localhost:8000', 'toArray', $sample              ], # Bad response from server (links is an array of arrays)
-['bob-links-missing-rel@localhost:8000', 'toArray', $sample         ], # Bad response from server (links key must contain a rel key)
-['bob-404-profile@localhost:8000', 'toArray', $sample               ], # Bad response from server (404 Not found)
+            ['bob@localhost:9000', 'toArray', $sample                           ], # Bad host with an Handle
+            ['bob', 'toArray', $sample                                             ], # Malformed handle
+            ['http://localhost:9000/accounts/bob', 'toArray', $sample           ], # Bad port with an AS id
+            ['http//localhost:8000/accounts/bob', 'toArray', $sample            ], # Bad scheme
+            ['bob-subject-array@localhost:8000', 'toArray', $sample             ], # Bad response from server (Subject is an array)
+            ['bob-malformed-aliases@localhost:8000', 'toArray', $sample         ], # Bad response from server (Aliases must be string[])
+            ['bob-missing-links@localhost:8000', 'toArray', $sample             ], # Bad response from server (links key is not defined)
+            ['bob-links-arrays@localhost:8000', 'toArray', $sample              ], # Bad response from server (links is an array of arrays)
+            ['bob-links-missing-rel@localhost:8000', 'toArray', $sample         ], # Bad response from server (links key must contain a rel key)
+            ['bob-404-profile@localhost:8000', 'toArray', $sample               ], # Bad response from server (404 Not found)
 
-['http://localhost:8000/accounts/empty-profile', 'toArray', $sample ], # Bad response from server (ActivityPhp profile is empty)
-['http://localhost:8000/accounts/missing-property', 'toArray', $sample ], # Bad response from server (Missing preferredUsername)
+            ['http://localhost:8000/accounts/empty-profile', 'toArray', $sample ], # Bad response from server (ActivityPhp profile is empty)
+            ['http://localhost:8000/accounts/missing-property', 'toArray', $sample ], # Bad response from server (Missing preferredUsername)
         ];
 	}
 
     /**
      * Check that all response are valid
-     *
-     * @dataProvider getSuccessScenarios
      */
+    #[DataProvider('getSuccessScenarios')]
     public function testSuccessScenarios($handle, $method, $expected)
     {
         $server = new Server([
@@ -106,9 +106,8 @@ class WebFingerTest extends TestCase
 
     /**
      * Check that all tests are failing
-     *
-     * @dataProvider      getFailingScenarios
      */
+    #[DataProvider('getFailingScenarios')]
     public function testFailingScenarios($handle, $method, $expected)
     {
         $this->expectException(Exception::class);
@@ -190,9 +189,8 @@ class WebFingerTest extends TestCase
 
     /**
      * Check that all tests are failing
-     *
-     * @dataProvider      getFailingInstanceScenarios
      */
+    #[DataProvider('getFailingInstanceScenarios')]
     public function testFailingInstanceScenarios($data)
     {
         $this->expectException(Exception::class);

--- a/tests/ActivityPhp/Type/AttributeFormatValidationTest.php
+++ b/tests/ActivityPhp/Type/AttributeFormatValidationTest.php
@@ -59,6 +59,7 @@ use ActivityPhp\Type\Extended\Object\Tombstone;
 use ActivityPhp\Type\Extended\Object\Video;
 use ActivityPhp\Type\Validator;
 use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class AttributeFormatValidationTest extends TestCase
@@ -1368,9 +1369,8 @@ class AttributeFormatValidationTest extends TestCase
     /**
      * Check that all core objects have a correct type property.
      * It checks that getter is working well too.
-     *
-     * @dataProvider      getValidAttributesScenarios
      */
+    #[DataProvider('getValidAttributesScenarios')]
     public function testValidAttributesScenarios($attr, $type, $value)
     {
         $object = new $type();
@@ -1396,9 +1396,7 @@ class AttributeFormatValidationTest extends TestCase
         $this->assertEquals($value, $object->{$attr});
     }
 
-    /**
-     * @dataProvider      getExceptionScenarios
-     */
+    #[DataProvider('getExceptionScenarios')]
     public function testExceptionScenarios($attr, $type, $value)
     {
         $this->expectException(Exception::class);

--- a/tests/ActivityPhp/Type/FactoryTest.php
+++ b/tests/ActivityPhp/Type/FactoryTest.php
@@ -6,6 +6,7 @@ use ActivityPhp\Type;
 use ActivityPhpTest\MyCustomType;
 use ActivityPhpTest\MyCustomValidator;
 use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class FactoryTest extends TestCase
@@ -77,9 +78,8 @@ class FactoryTest extends TestCase
 
     /**
      * Check that all core objects have a correct type property.
-     *
-     * @dataProvider getShortTypes
      */
+    #[DataProvider('getShortTypes')]
     public function testShortTypesInstanciation($type)
     {
         $class = Type::create($type, ['name' => strtolower($type)]);

--- a/tests/ActivityPhp/Type/TypesTypeAttributeTest.php
+++ b/tests/ActivityPhp/Type/TypesTypeAttributeTest.php
@@ -56,6 +56,7 @@ use ActivityPhp\Type\Extended\Object\Profile;
 use ActivityPhp\Type\Extended\Object\Relationship;
 use ActivityPhp\Type\Extended\Object\Tombstone;
 use ActivityPhp\Type\Extended\Object\Video;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class TypesTypeAttributeTest extends TestCase
@@ -124,15 +125,14 @@ class TypesTypeAttributeTest extends TestCase
 		];
 	}
 
-	/**
-	 * Check that all core objects have a correct type property.
-	 * It checks that getter is working well too.
-	 *
-	 * @dataProvider      getObjectTypeScenarios
-	 */
-	public function testObjectTypeScenarios($type, $attr, $value)
-	{
-		$object = new $type();
-		$this->assertEquals($value, $object->{$attr});
-	}
+    /**
+     * Check that all core objects have a correct type property.
+     * It checks that getter is working well too.
+     */
+    #[DataProvider('getObjectTypeScenarios')]
+    public function testObjectTypeScenarios($type, $attr, $value)
+    {
+        $object = new $type();
+        $this->assertEquals($value, $object->{$attr});
+    }
 }


### PR DESCRIPTION
Bonjour du Québec!

Thanks for this library!

# Details of this PR:

Annotations (at least for marking a method as a Data Provider) are no longer supported in PHPUnit <12.

Therefore I:

- [x] changed the syntax everywhere, to make the tests pass again.
- [x] took the opportunity to fix some indentations here and there, and adding a `.editorconfig` to the project so it's enforced (for those who have the proper editor plugin installed) in the future.
- [x] removed support for PHP 7.x since that major version is longer being supported by the language maintainers.
- [x] gave some love to `.gitignore`