### PR TITLE
Switch default logger to PSR-3 NullLogger

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "require": {
         "php": "^8.0",
         "guzzlehttp/guzzle": ">=6.3",
-        "monolog/monolog": "^1.12|^2.0|^3.0",
+        "psr/log": "^1.0|^2.0|^3.0",
         "symfony/http-foundation": ">=3.4",
         "phpseclib/phpseclib": "^3.0.7",
         "psr/cache": "^1.0|^2.0|^3.0",

--- a/docs/server/server-implementation.md
+++ b/docs/server/server-implementation.md
@@ -72,19 +72,19 @@ ________________________________________________________________________
 
 - channel: A string defining a log channel. Default is 'global'
 
-- loglevel: Minimal loglevel. Default is Logger::DEBUG (@todo put all monolog 
-    allowed config)
-    
+- loglevel: Minimal loglevel. This is only relevant for PSR-3 compatible loggers
+    that support log levels (like Monolog)
+
 - stream: Where to put log messages. Default is 'php://stdout'.
         It can be a filename.
 
-________________________________________________________________________                
+________________________________________________________________________
 
 
 ### instance parameters
 
 - hostname
-- debug: boolean. 
+- debug: boolean.
     default = false
 
 

--- a/docs/server/server-usage.md
+++ b/docs/server/server-usage.md
@@ -73,7 +73,8 @@ If you have specific needs (Storing logs into a database, for
 instance), you may pass a custom logger driver. As it implements
 `Psr\Log\LoggerInterface`, you may pass any custom logger.
 
-By default, the driver is [Monolog\Logger](https://github.com/Seldaek/monolog).
+By default, the driver is `Psr\Log\NullLogger` which discards all log messages.
+You can use any PSR-3 compatible logger such as [Monolog](https://github.com/Seldaek/monolog).
 
 
 **stream**

--- a/src/ActivityPhp/Server/Configuration/LoggerConfiguration.php
+++ b/src/ActivityPhp/Server/Configuration/LoggerConfiguration.php
@@ -12,18 +12,17 @@
 namespace ActivityPhp\Server\Configuration;
 
 use Exception;
-use Monolog\Handler\StreamHandler;
-use Monolog\Logger;
+use Psr\Log\NullLogger;
 
 /**
  * Logger configuration stack
- */ 
+ */
 class LoggerConfiguration extends AbstractConfiguration
 {
     /**
      * @var string Logger class name
      */
-    protected $driver = '\Monolog\Logger';
+    protected $driver = '\Psr\Log\NullLogger';
 
     /**
      * @var string Logger stream
@@ -37,7 +36,7 @@ class LoggerConfiguration extends AbstractConfiguration
 
     /**
      * Dispatch configuration parameters
-     * 
+     *
      * @param array $params
      */
     public function __construct(array $params = [])
@@ -47,7 +46,7 @@ class LoggerConfiguration extends AbstractConfiguration
 
     /**
      * Create logger instance
-     * 
+     *
      * @return \Psr\Log\LoggerInterface
      */
     public function createLogger()
@@ -58,16 +57,7 @@ class LoggerConfiguration extends AbstractConfiguration
             );
         }
 
-        $logger = new $this->driver($this->channel);
-
-        if (method_exists($logger, 'pushHandler')) {
-            $logger->pushHandler(
-                new StreamHandler(
-                    $this->stream,
-                    Logger::DEBUG
-                )
-            );
-        }
+        $logger = new $this->driver();
 
         return $logger;
     }


### PR DESCRIPTION
Replaces Monolog as the default logger with Psr\Log\NullLogger in LoggerConfiguration. Updates composer.json to require psr/log instead of monolog/monolog, and revises documentation to reflect the new default and clarify logger usage. This change reduces dependencies and allows for any PSR-3 compatible logger to be used.