### PR TITLE
Allow cacert.pem file to be specified for HTTP Requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "symfony/cache": ">=4.0"
     },
     "require-dev": {
+        "paragonie/certainty": "^2|^3",
         "phpunit/phpunit": "*"
     },
     "autoload": {

--- a/src/ActivityPhp/Server/Configuration/HttpConfiguration.php
+++ b/src/ActivityPhp/Server/Configuration/HttpConfiguration.php
@@ -40,6 +40,11 @@ class HttpConfiguration extends AbstractConfiguration
     protected $sleep = 5;
 
     /**
+     * @var string File path for cacert.pem file for TLS validation
+     */
+    protected string $cacertPath = '';
+
+    /**
      * Dispatch configuration parameters
      *
      * @param array $params

--- a/src/ActivityPhp/Server/Http/Request.php
+++ b/src/ActivityPhp/Server/Http/Request.php
@@ -69,7 +69,7 @@ class Request
      * @param float|int $timeout
      * @param string $agent
      */
-    public function __construct($timeout = 10.0, $agent = '')
+    public function __construct(float|int $timeout = 10.0, string $agent = '', string $cacertPath = '')
     {
         $headers = ['Accept' => self::HTTP_HEADER_ACCEPT];
 
@@ -77,10 +77,17 @@ class Request
             $headers['User-Agent'] = $agent;
         }
 
-        $this->client = new Client([
+        $clientConfig = [
             'timeout' => $timeout,
             'headers' => $headers
-        ]);
+        ];
+        if (!empty($cacertPath)) {
+            if (!is_readable($cacertPath)) {
+                throw new Exception('Cannot read cacert file path: ' . $cacertPath);
+            }
+            $clientConfig['verify'] = $cacertPath;
+        }
+        $this->client = new Client($clientConfig);
     }
 
     /**

--- a/src/ActivityPhp/Server/Http/WebFingerFactory.php
+++ b/src/ActivityPhp/Server/Http/WebFingerFactory.php
@@ -70,7 +70,8 @@ class WebFingerFactory
         $content = Util::decodeJson(
             (new Request(
                 self::$server->config('http.timeout'),
-                self::$server->config('http.agent')
+                self::$server->config('http.agent'),
+                self::$server->config('http.cacert') ?? ''
             ))->get($url)
         );
 

--- a/tests/ActivityPhp/Server/ServerHttpTest.php
+++ b/tests/ActivityPhp/Server/ServerHttpTest.php
@@ -3,6 +3,7 @@
 namespace ActivityPhpTest\Server;
 
 use ActivityPhp\Server;
+use ParagonIE\Certainty\RemoteFetch;
 use PHPUnit\Framework\TestCase;
 
 class ServerHttpTest extends TestCase
@@ -58,6 +59,23 @@ class ServerHttpTest extends TestCase
         $this->assertEquals(
             Server::server()->config('http.agent'),
             "MyUserAgent"
+        );
+    }
+
+    public function testCaCert()
+    {
+        mkdir(__DIR__ . '/tmp');
+        $latestCaCert = (new RemoteFetch(__DIR__ . '/tmp'))
+            ->getLatestBundle(false, false)
+            ->getFilePath();
+        $server = new Server([
+            'http' => [
+                'cacert' => $latestCaCert
+            ]
+        ]);
+        $this->assertSame(
+            $latestCaCert,
+            $server->config('http.cacert')
         );
     }
 }


### PR DESCRIPTION
This also pulls in paragonie/certainty as a dev-dependency for unit testing purposes.

Fixes #47.